### PR TITLE
Constrain images in .list1

### DIFF
--- a/css/camera.css
+++ b/css/camera.css
@@ -49,7 +49,7 @@
 	display: none;
 }
 .cameraCont, .cameraContents {
-	height: 100%;
+	height: calc(100% + 25px);
 	position: relative;
 	width: 100%;
 	z-index: 1;	
@@ -61,6 +61,13 @@
 	right: 0;
 	top: 0;
 	width: 100%;
+}
+.cameraSlide img {
+    position: absolute;
+    z-index: -1;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 .camera_target {

--- a/css/style.css
+++ b/css/style.css
@@ -531,7 +531,9 @@ header {
 	margin-right: 20px;
 }
 .list3 li figure img {
-	width: 100%;
+    width: 188px;
+    height: 207px;
+    object-fit: cover;
 }
 .list3 li .info1 {
 	overflow: hidden;

--- a/css/style.css
+++ b/css/style.css
@@ -1531,6 +1531,7 @@ footer {
 	width: 100%;
 	float: none;
 	margin-right: 0;
+	text-align: center;
 }
 .list3 li .info1 {
 	overflow: hidden;

--- a/css/style.css
+++ b/css/style.css
@@ -458,8 +458,9 @@ header {
 .list1 li div figure img {
     position: relative;
     margin: -50% auto;
-    height: auto;
+    height: calc(100% + 3px);
     vertical-align: middle;
+	object-fit: cover;
 }
 .box1 {
 	background: #eb5368;

--- a/css/style.css
+++ b/css/style.css
@@ -449,6 +449,18 @@ header {
 	-webkit-transition: all 0.2s ease;
 	transition: all 0.2s ease;
 }
+.list1 li div figure {
+    overflow: hidden;
+    width: 100%;
+    height: 250px;
+    line-height: 250px;
+}
+.list1 li div figure img {
+    position: relative;
+    margin: -50% auto;
+    height: auto;
+    vertical-align: middle;
+}
 .box1 {
 	background: #eb5368;
 }


### PR DESCRIPTION
Patch to constrain and center-crop images used in three boxes under the
"Welcome" text block on the home page.
This permits flexibility with different image size ratios.